### PR TITLE
ci: open mirror updates as PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,8 @@ jobs:
     name: main
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # Push the auto/update-mirror branch and mirror tags.
+      pull-requests: write # Create and auto-merge the mirror PR.
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -20,8 +21,56 @@ jobs:
       - run: git config --global user.name 'Github Actions'
       - run: git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
       - run: pre-commit-mirror . --language=node --package-name=oxlint --description="Linter for the JavaScript Oxidation Compiler" --types-or=javascript --types-or=jsx --types-or=ts --types-or=tsx
-      - run: |
-          git remote set-url origin https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY
-          git push origin HEAD:refs/heads/main --tags
+
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Prepare mirror update
+        id: mirror
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          if [ "$(git rev-list --count origin/main..HEAD)" = "0" ]; then
+            echo "No mirror updates"
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git remote set-url origin "https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY"
+
+          for tag in $(git tag --list); do
+            if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null; then
+              echo "Tag $tag already exists"
+            else
+              git push origin "refs/tags/$tag"
+            fi
+          done
+
+          git reset --mixed origin/main
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        if: steps.mirror.outputs.updated == 'true'
+        id: cpr
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: auto/update-mirror
+          delete-branch: true
+          base: main
+          title: "chore: update pre-commit mirror"
+          commit-message: "chore: update pre-commit mirror"
+          body: Automated pre-commit mirror update triggered by a change to `main`.
+          add-paths: |
+            .pre-commit-hooks.yaml
+            .version
+            package.json
+
+      - uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3
+        if: steps.cpr.outputs.pull-request-number
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Its job is to publish and maintain the files/tags needed so users can run `oxlin
 
 ## How it works
 
-- `.github/workflows/main.yml` runs `pre-commit-mirror-maker` on pushes to `main`.
+- `.github/workflows/main.yml` runs `pre-commit-mirror-maker` on pushes to `main` and opens a mirror update PR.
 - `.pre-commit-hooks.yaml` defines the hook metadata (`id`, `entry`, dependency version, file types).
 - `.version` stores the currently mirrored package version.
 
-The workflow regenerates mirror content and pushes updates (including tags) back to this repository.
+The workflow regenerates mirror content, pushes missing tags, and opens an auto-merge PR for mirror updates.
 
 ## Updating
 
@@ -19,4 +19,4 @@ When a new `oxlint` release should be mirrored:
 
 1. Update `.version` to that npm version.
 2. Keep `.pre-commit-hooks.yaml` `additional_dependencies` aligned with the same version.
-3. Push to `main` to run the workflow.
+3. Push to `main` to run the workflow and open the mirror update PR.


### PR DESCRIPTION
Convert the mirror workflow from direct `main` pushes to a `peter-evans/create-pull-request` flow. It pushes missing mirror tags with the app token, opens or updates `auto/update-mirror`, and enables squash auto-merge.

Validated with YAML parsing, embedded shell syntax checking, and `git diff --check`.